### PR TITLE
eject: Additionally remove `react-scripts` from dependencies

### DIFF
--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -93,8 +93,14 @@ prompt(
 
   console.log(cyan('Updating the dependencies'));
   var ownPackageName = ownPackage.name;
-  console.log('  Removing ' + cyan(ownPackageName) + ' from devDependencies');
-  delete appPackage.devDependencies[ownPackageName];
+  if(appPackage.devDependencies[ownPackageName]){
+    console.log('  Removing ' + cyan(ownPackageName) + ' from devDependencies');
+    delete appPackage.devDependencies[ownPackageName];
+  }
+  if(appPackage.dependencies[ownPackageName]){
+    console.log('  Removing ' + cyan(ownPackageName) + ' from dependencies');
+    delete appPackage.dependencies[ownPackageName];
+  }
 
   Object.keys(ownPackage.dependencies).forEach(function (key) {
     // For some reason optionalDependencies end up in dependencies after install


### PR DESCRIPTION
ATM if react-scripts is (erroneously) declared in `dependencies` instead of `devDependencies` or isn't declared at all, the `eject` script will fail half-way. This change makes it more robust, react-scripts will be removed from either, if present.